### PR TITLE
lazy rewrite

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,4 +37,4 @@ jobs:
     - name: Test
       run: cargo test --verbose
     - name: Make sure clean can run
-      run: cargo run -- clean tests/examples -r
+      run: cargo run --features cli -- clean tests/examples -r

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,11 @@ jobs:
       run: |
         git config --global core.autocrlf false
     - uses: actions/checkout@v3
+    - name: Setup Rust
+      uses: ATiltedTree/setup-rust@v1
+      with:
+        rust-version: stable
+        components: clippy
     - uses: actions/cache@v2
       with:
         path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.1
+- Temp files are no longer re-written if they are already up-to-date in both verify and build mode 
+- New flag `--needed/-N` and corresponding mode `InMemoryBuild` that stores the fresh output in memory and only writes the file if different
+
 ## 0.2.0
 - Verify mode no longer re-writes temp files if they are already up-to-date.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "txtpp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "copy_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "txtpp"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "A simple-to-use general purpose preprocessor for text files."
 repository = "https://github.com/Pistonite/txtpp"
@@ -20,10 +20,13 @@ which = "^4.4.0"
 error-stack = "^0.3.1"
 termcolor = "^1.2.0"
 threadpool = "^1.8.1"
-clap = { version = "^4.2.4", features = ["cargo", "derive"] }
+clap = { version = "^4.2.4", features = ["cargo", "derive"], optional = true }
 log = "^0.4.17"
 env_logger = "^0.10.0"
 derivative = "^2.2.0"
+
+[features]
+cli = ["clap"]
 
 [dev-dependencies]
 copy_dir = "^0.1.2"
@@ -32,6 +35,7 @@ murmur3 = "^0.5.2"
 [[bin]]
 name = "txtpp"
 path = "src/main.rs"
+required-features = ["cli"]
 
 [lib]
 name = "txtpp"

--- a/Justfile
+++ b/Justfile
@@ -5,26 +5,22 @@ install:
     rustup update
     cargo install cargo-watch
 
-# List TODOs
-todo:
-    grep -rn TODO src examples tests CHANGELOG.md README.md
-
 # Clean example output
 clean:
-    cargo run -- clean tests/examples docs -r
+    cargo run --features cli -- clean tests/examples docs -r
 
 # Generate the readme
 readme:
-    cargo run docs/README.md
+    cargo run --features cli docs/README.md
     mv docs/README.md README.md
 
 # Pre-commit checks
-pre-commit: && readme clean
+check: && readme clean
     cargo clippy --all-targets --all-features -- -D warnings
     cargo fmt
     cargo doc
     cargo test
 
 # Build and open docs
-doc: pre-commit
+doc: check
     cargo doc --open

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ function get_cities() {
         //     reader = csv.reader(f)
         //     next(reader) # skip header
         //     for city, country in reader:
-        //         print(f'{{ city: "{city}", country: "{country}"}},')
+        //         print(f"{{ city: \"{city}\", country: \"{country}\"}},")
         /* --- generated code --- */
         // TXTPP#run python gen_cities.g.py
         /* --- generated code --- */
@@ -272,6 +272,7 @@ function get_cities() {
 }
 // Note we used /*  */ to break the prefix pattern `// ` so that the directive can end
 // You can also use an empty line to make it simple.
+
 ```
 ## Tag Directive
 #### USAGE

--- a/src/core/execute/config.rs
+++ b/src/core/execute/config.rs
@@ -77,7 +77,12 @@ pub enum Mode {
     /// For every `.txtpp` file found from the inputs, it will build the output file and any temporary file
     /// the `.txtpp` may produce. Dependencies in `include` directives will be built automatically as well, even if
     /// not specified in the inputs.
+    ///
+    /// Note that the temporary files are be rebuilt in the process in order to generate the fresh output.
+    /// However, temporary files that already have the same content will not be re-written to avoid changing the modification time.
     Build,
+    /// Build output files with the --needed flag
+    InMemoryBuild,
     /// Delete output files
     ///
     /// Remove the output file and any temporary file the `.txtpp` input files may produce.
@@ -87,23 +92,23 @@ pub enum Mode {
     ///
     /// In this mode, the output files will be compared against output from a fresh run.
     /// The run will fail if any output is different from the fresh output.
-    /// Note that the temporary files may be rebuilt in the process in order to generate the fresh output.
+    ///
+    /// Note that the temporary files are rebuilt in the process in order to generate the fresh output.
     /// However, temporary files that already have the same content will not be re-written to avoid changing the modification time.
-    /// Therefore it is safe to wrap `txtpp verify` with other tools that watch for changes.
     Verify,
 }
 
 impl Mode {
     pub fn processing_verb(&self) -> &'static str {
         match self {
-            Self::Build => verbs::PROCESSING,
+            Self::Build | Self::InMemoryBuild => verbs::PROCESSING,
             Self::Clean => verbs::CLEANING,
             Self::Verify => verbs::VERIFYING,
         }
     }
     pub fn processed_verb(&self) -> &'static str {
         match self {
-            Self::Build => verbs::PROCESSED,
+            Self::Build | Self::InMemoryBuild => verbs::PROCESSED,
             Self::Clean => verbs::CLEANED,
             Self::Verify => verbs::VERIFIED,
         }

--- a/src/fs/io_context.rs
+++ b/src/fs/io_context.rs
@@ -159,22 +159,19 @@ impl IOCtx {
             return Err(Report::new(make_error!(self, PpErrorKind::WriteFile))
                 .attach_printable(format!("cannot write to directory: `{export_file}`")));
         }
-            // Check if the temp file already exists and has the same content
-            if export_file.as_path().exists() {
-                let current_content =
-                    fs::read_to_string(&export_file)
-                        .into_report()
-                        .map_err(|e| {
-                            e.change_context(make_error!(self, PpErrorKind::ReadFile))
-                                .attach_printable(format!(
-                                    "could not read temp file: `{export_file}`"
-                                ))
-                        })?; // if we can't read it, we probably can't write it either
-                if current_content == contents {
-                    log::debug!("temp file already exists with same content, skipping");
-                    return Ok(());
-                }
+        // Check if the temp file already exists and has the same content
+        if export_file.as_path().exists() {
+            let current_content = fs::read_to_string(&export_file)
+                .into_report()
+                .map_err(|e| {
+                    e.change_context(make_error!(self, PpErrorKind::ReadFile))
+                        .attach_printable(format!("could not read temp file: `{export_file}`"))
+                })?; // if we can't read it, we probably can't write it either
+            if current_content == contents {
+                log::debug!("temp file already exists with same content, skipping");
+                return Ok(());
             }
+        }
 
         fs::write(&export_file, contents)
             .into_report()

--- a/src/fs/io_context.rs
+++ b/src/fs/io_context.rs
@@ -12,7 +12,9 @@ use std::path::{Path, PathBuf};
 /// This is an IO wrapper for reading from txtpp file and writing to the output file.
 #[derive(Debug)]
 pub struct IOCtx {
+    /// Input reader
     input: Lines<BufReader<File>>,
+    /// Output wrapper
     out: CtxOut,
     pub cur_line: usize,
     pub work_dir: AbsPath,
@@ -105,6 +107,10 @@ impl IOCtx {
                         .attach_printable(format!("cannot write to `{}`", path.display()))
                 })
             }
+            CtxOut::InMemoryBuild { out, .. } => {
+                out.push_str(output);
+                Ok(())
+            }
             CtxOut::Clean { .. } => Ok(()), // do nothing
             CtxOut::Verify { path, out, rem } => {
                 log::debug!("verifying content: {output:?}");
@@ -153,7 +159,6 @@ impl IOCtx {
             return Err(Report::new(make_error!(self, PpErrorKind::WriteFile))
                 .attach_printable(format!("cannot write to directory: `{export_file}`")));
         }
-        if let CtxOut::Verify { .. } = self.out {
             // Check if the temp file already exists and has the same content
             if export_file.as_path().exists() {
                 let current_content =
@@ -170,7 +175,7 @@ impl IOCtx {
                     return Ok(());
                 }
             }
-        }
+
         fs::write(&export_file, contents)
             .into_report()
             .map_err(|e| {
@@ -186,6 +191,28 @@ impl IOCtx {
                 e.change_context(make_error!(self, PpErrorKind::WriteFile))
                     .attach_printable(format!("cannot write to `{}`", path.display()))
             }),
+            CtxOut::InMemoryBuild { path, out } => {
+                if path.as_path().exists() {
+                    let current_content = fs::read_to_string(&path).into_report().map_err(|e| {
+                        e.change_context(make_error!(self, PpErrorKind::ReadFile))
+                            .attach_printable(format!(
+                                "could not read existing output file: `{path}`",
+                                path = path.display()
+                            ))
+                    })?; // if we can't read it, we probably can't write it either
+                    if &current_content == out {
+                        log::debug!("output file already exists with same content, skipping");
+                        return Ok(());
+                    }
+                }
+                fs::write(&path, out).into_report().map_err(|e| {
+                    e.change_context(make_error!(self, PpErrorKind::WriteFile))
+                        .attach_printable(format!(
+                            "could not write output file: `{path}`",
+                            path = path.display()
+                        ))
+                })
+            }
             CtxOut::Clean { .. } => Ok(()), // do nothing
             CtxOut::Verify { path, rem, .. } => {
                 if *rem != 0 {
@@ -233,11 +260,31 @@ use make_verify_report;
 /// Output context, which depends on the mode.
 #[derive(Debug)]
 enum CtxOut {
+    /// Build mode.
+    ///
+    /// Write to the output file.
     Build {
+        /// Path to the output file
         path: PathBuf,
+        /// Output writer
         out: BufWriter<File>,
     },
+    /// Build mode in memory
+    ///
+    /// Write to the output file.
+    InMemoryBuild {
+        /// Path to the output file
+        path: PathBuf,
+        /// Output buffer
+        out: String,
+    },
+    /// Clean mode.
+    ///
+    /// Delete the output file and temporary files and do nothing when writing
     Clean,
+    /// Verify mode.
+    ///
+    /// Read existing file and verify that it is the same as the fresh output
     Verify {
         path: PathBuf,
         out: BufReader<File>,
@@ -270,6 +317,10 @@ impl CtxOut {
                     path: output_path.as_ref().to_path_buf(),
                 })
             }
+            Mode::InMemoryBuild => Ok(Self::InMemoryBuild {
+                out: String::new(),
+                path: output_path.as_ref().to_path_buf(),
+            }),
             Mode::Clean => {
                 let p = output_path.as_ref();
                 if p.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ struct Cli {
     /// `cargo watch`.
     ///
     /// Note that this will increase memory usage and may fail if the file cannot fit in memory.
-    #[arg(short='N', long)]
+    #[arg(short = 'N', long)]
     needed: bool,
 }
 
@@ -33,7 +33,11 @@ impl Cli {
         match &self.subcommand {
             Some(subcommand) => subcommand.apply_to(config),
             None => {
-                config.mode = if self.needed { Mode::InMemoryBuild } else { Mode::Build };
+                config.mode = if self.needed {
+                    Mode::InMemoryBuild
+                } else {
+                    Mode::Build
+                };
                 self.flags.apply_to(config);
                 self.shell.apply_to(config);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,17 @@ struct Cli {
     flags: Flags,
     #[command(flatten)]
     shell: BuildFlags,
+
+    /// Only touch output file if the content need to change
+    ///
+    /// This will keep the fresh output in memory until the end, and compare it
+    /// with the existing output file. If the content is the same, the output
+    /// will not be written. This is useful when running txtpp will a watch system like
+    /// `cargo watch`.
+    ///
+    /// Note that this will increase memory usage and may fail if the file cannot fit in memory.
+    #[arg(short='N', long)]
+    needed: bool,
 }
 
 impl Cli {
@@ -22,7 +33,7 @@ impl Cli {
         match &self.subcommand {
             Some(subcommand) => subcommand.apply_to(config),
             None => {
-                config.mode = Mode::Build;
+                config.mode = if self.needed { Mode::InMemoryBuild } else { Mode::Build };
                 self.flags.apply_to(config);
                 self.shell.apply_to(config);
             }


### PR DESCRIPTION
- Temp files are no longer re-written if they are already up-to-date in both verify and build mode 
- New flag `--needed/-N` and corresponding mode `InMemoryBuild` that stores the fresh output in memory and only writes the file if different